### PR TITLE
support pysam 0.15.1

### DIFF
--- a/bin/tigmint-molecule
+++ b/bin/tigmint-molecule
@@ -121,7 +121,7 @@ class MolecIdentifier:
                 prev_val1 = 0
                 prev_val2 = 0
                 start = cur_reads[0].pos
-                rname = cur_reads[0].reference_name
+                rname = samfile.references[cur_reads[0].reference_id]
                 inter_arrivals = []
                 mapqs = []
                 scores = []


### PR DESCRIPTION
The object pysam.calignmentfile.AlignedSegment in pysam 0.15.1 only support reference_id and reference_name is deprecated.