### PR TITLE
If span=auto used with ntLink mappings, throw error

### DIFF
--- a/bin/.pylintrc
+++ b/bin/.pylintrc
@@ -1,5 +1,6 @@
 [basic]
 max-args = 8
+max-line-length = 120
  
 [MISCELLANEOUS]
 

--- a/bin/tigmint-make
+++ b/bin/tigmint-make
@@ -292,7 +292,7 @@ endif
 endif
 
 ifeq ($(mapping), ntLink)
-	$(gtime) $(bin)/tigmint-ntlink-map --bed $@ -k$(ntLink_k) -w$(ntLink_w) -t$t --path $(bin) -m$(minsize) $(draft) $<
+	$(gtime) $(bin)/tigmint-ntlink-map --bed $@ -k$(ntLink_k) -w$(ntLink_w) -t$t --path $(bin) -m$(minsize) --span $(span) $(draft) $<
 else
 	$(gtime) sh -c '$(bin)/../src/long-to-linked-pe -l $(cut) -m$(minsize) -g$G -s -b $(reads).barcode-multiplicity.tsv --bx -t$t --fasta -f $(reads).tigmint-long.params.tsv $< | \
 	minimap2 -y -t$t -x map-$(longmap) --secondary=no $(draft).fa - | \

--- a/bin/tigmint-ntlink-map
+++ b/bin/tigmint-ntlink-map
@@ -23,7 +23,7 @@ def run_tigmint_filter_paf(args):
         script_loc = f"{args.path}/{script_loc}"
 
     command_1_shlex = shlex.split(f"{script_loc} -m {args.m} {args.target}.fa.k{args.k}.w{args.w}.z1000.paf")
-    command_2_shlex = shlex.split(f"sort -k1,1 -k2,2n -k3,3n")
+    command_2_shlex = shlex.split("sort -k1,1 -k2,2n -k3,3n")
 
     with open(args.bed, "wb") as outfile:
         process_1 = subprocess.Popen(command_1_shlex, stdout=subprocess.PIPE)
@@ -53,7 +53,8 @@ def main():
     args = parser.parse_args()
 
     if args.span == "auto":
-        raise ValueError("Error: span=auto is currently not compatible with using ntLink for mapping. Please specify an integer value for span. " \
+        raise ValueError("Error: span=auto is currently not compatible with using ntLink for mapping. " \
+            "Please specify an integer value for span. " \
             "When using ntLink for mapping, we recommend the span value to be between 2-10.")
 
     run_ntlink_pair(args)

--- a/bin/tigmint-ntlink-map
+++ b/bin/tigmint-ntlink-map
@@ -48,8 +48,13 @@ def main():
     parser.add_argument("--path", help="Path to directory with tigmint-fiter-paf executable, "
                                        "if not in PATH", type=str)
     parser.add_argument("-m", help="Minimum size for mapping block (bp) [2000]", default=2000, type=int)
+    parser.add_argument("--span", help="Span value specified for tigmint-cut", required=True)
 
     args = parser.parse_args()
+
+    if args.span == "auto":
+        raise ValueError("Error: span=auto is currently not compatible with using ntLink for mapping. Please specify an integer value for span. " \
+            "When using ntLink for mapping, we recommend the span value to be between 2-10.")
 
     run_ntlink_pair(args)
     run_tigmint_filter_paf(args)


### PR DESCRIPTION
* Currently, `span=auto` is not compatible with using ntLink for mappings
* If these options are specified together, throw an error which describes the issue and makes a suggestion for improvement