### PR TITLE
Allow flexible installation location of long-to-linked-pe

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
     displayName: Create Anaconda environment
   - script: |
       source activate tigmint_CI
-      conda install --yes --quiet --name tigmint_CI -c conda-forge -c bioconda mamba python=3.9
+      conda install --yes --quiet --name tigmint_CI -c conda-forge -c bioconda mamba python=3.8
       mamba install --yes --quiet -c conda-forge -c bioconda pytest bedtools bwa samtools=1.9 minimap2 pylint btllib compilers ntlink
       mamba install --yes --quiet -c conda-forge -c bioconda --file requirements.txt
     displayName: Install Anaconda packages

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ jobs:
     displayName: Compile C++ executables
   - script: |
       source activate tigmint_CI
-      conda install --yes -c bioconda -c conda-forge clang clang-tools
+      mamba install --yes -c bioconda -c conda-forge clang clang-tools
       make -C src lint
     displayName: Run clang-format and clang-tidy
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,8 +14,9 @@ jobs:
     displayName: Create Anaconda environment
   - script: |
       source activate tigmint_CI
-      conda install --yes --quiet --name tigmint_CI -c conda-forge -c bioconda pytest bedtools bwa samtools=1.9 minimap2 pylint 'btllib<=1.4.10' compilers ntlink
-      conda install --yes --quiet --name tigmint_CI -c conda-forge -c bioconda --file requirements.txt
+      conda install --yes --quiet --name tigmint_CI -c conda-forge -c bioconda mamba python=3.9
+      mamba install --yes --quiet -c conda-forge -c bioconda pytest bedtools bwa samtools=1.9 minimap2 pylint btllib compilers ntlink
+      mamba install --yes --quiet -c conda-forge -c bioconda --file requirements.txt
     displayName: Install Anaconda packages
   - script: |
       source activate tigmint_CI
@@ -34,6 +35,7 @@ jobs:
     displayName: Run pylint
   - script: |
       source activate tigmint_CI
+      export PATH=$(pwd)/bin:$PATH
       cd tests
       pytest -vs tigmint_test.py
     displayName: Run pytests

--- a/bin/tigmint-make
+++ b/bin/tigmint-make
@@ -127,6 +127,12 @@ ifdef bin
 PATH:=$(bin):$(PATH)
 endif
 
+# Determine path to long-to-linked-pe script
+src_path=$(bin)/../src
+ifneq ($(shell command -v long-to-linked-pe),)
+src_path=$(shell dirname $(shell command -v long-to-linked-pe))
+endif
+
 # Use pigz or bgzip for parallel compression if available.
 ifneq ($(shell command -v pigz),)
 gzip=pigz -p$t
@@ -302,7 +308,7 @@ endif
 ifeq ($(mapping), ntLink)
 	$(gtime) $(bin)/tigmint-ntlink-map --bed $@ -k$(ntLink_k) -w$(ntLink_w) -t$t --path $(bin) -m$(minsize) --span $(span) $(draft) $<
 else
-	$(gtime) sh -c '$(bin)/../src/long-to-linked-pe -l $(cut) -m$(minsize) -g$G -s -b $(reads).barcode-multiplicity.tsv --bx -t$t --fasta -f $(reads).tigmint-long.params.tsv $< | \
+	$(gtime) sh -c '$(src_path)/long-to-linked-pe -l $(cut) -m$(minsize) -g$G -s -b $(reads).barcode-multiplicity.tsv --bx -t$t --fasta -f $(reads).tigmint-long.params.tsv $< | \
 	minimap2 -y -t$t -x map-$(longmap) --secondary=no $(draft).fa - | \
 	$(bin)/tigmint_molecule_paf.py -q$(mapq) -s$(minsize) $(dist_options) - | sort -k1,1 -k2,2n -k3,3n $(SORT_OPTS) > $@'
 endif

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ intervaltree
 pybedtools
 pysam
 numpy
-btllib <=1.4.10
+btllib

--- a/tests/test_installation/run_tigmint_demo.sh
+++ b/tests/test_installation/run_tigmint_demo.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
+echo "Please ensure that tigmint-make is in your PATH!"
+
 echo "Running tigmint with linked reads..."
 
-../../bin/tigmint-make -B tigmint draft=test_contig reads=test_linkedreads
+tigmint-make -B tigmint draft=test_contig reads=test_linkedreads
 
 echo "Running tigmint with long reads..."
 
-../../bin/tigmint-make -B tigmint-long draft=test_contig_long reads=test_longreads span=10 G=7000 dist=auto
+tigmint-make -B tigmint-long draft=test_contig_long reads=test_longreads span=10 G=7000 dist=auto
 
 echo "Done! Compare your output files to those in the 'expected_outputs' directory to ensure that the run was successful."


### PR DESCRIPTION
* If already found on the PATH, use that path, else in src dir
* Also remove unneeded btllib version restriction in requirements.txt